### PR TITLE
Update Exercise2.cs

### DIFF
--- a/BasicExercises/Exercise2.cs
+++ b/BasicExercises/Exercise2.cs
@@ -96,10 +96,19 @@ namespace BasicExercises
         }
     }
 
-    public struct InventoryItem
+    public struct InventoryItem : IEquatable<InventoryItem>
     {
         public string Name { get; set; }
 
         public int Count { get; set; }
+
+        public bool Equals(InventoryItem other) =>
+            string.Equals(Name, other.Name, StringComparison.OrdinalIgnoreCase);
+
+        public override bool Equals(object obj) =>
+            obj is InventoryItem i && Equals(i);
+
+        public override int GetHashCode() => Name.GetHashCode();
+
     }
 }


### PR DESCRIPTION
Based on Codacy compliance:
`If you're using a struct, it is likely because you're interested in performance. But by failing to implement IEquatable<T> you're losing performance when comparisons are made because without IEquatable<T>, boxing and reflection are used to make comparisons.`
Link to an article as a sample - https://blog.entityadam.com/c%23/2020/01/21/value-types-iequatable/